### PR TITLE
Change to use AWS DynamoDB Client

### DIFF
--- a/src/AwsWrappers/DynamoDbItem.php
+++ b/src/AwsWrappers/DynamoDbItem.php
@@ -98,6 +98,10 @@ class DynamoDbItem implements \ArrayAccess
         
         switch ($type) {
             case self::ATTRIBUTE_TYPE_STRING: {
+                if(is_object($v)) {
+                    return [$type => (serialize($v))];
+                }
+
                 if (strlen(strval($v))) {
                     return [$type => strval($v)];
                 }
@@ -143,6 +147,10 @@ class DynamoDbItem implements \ArrayAccess
                 return [$type => $children];
             }
                 break;
+
+            case 'object':
+                return [self::ATTRIBUTE_TYPE_STRING => (serialize($v))];
+
             default: {
                 $const_key = __CLASS__ . "::ATTRIBUTE_TYPE_" . strtoupper($type);
                 if (defined($const_key)) {

--- a/src/AwsWrappers/DynamoDbManager.php
+++ b/src/AwsWrappers/DynamoDbManager.php
@@ -13,15 +13,12 @@ use Aws\Result;
 
 class DynamoDbManager
 {
-    /** @var array */
-    protected $config;
-    /** @var  DynamoDbClient */
+    /** @var DynamoDbClient */
     protected $db;
-    
-    public function __construct(array $awsConfig)
+
+    public function __construct(DynamoDbClient $dbClient)
     {
-        $dp       = new AwsConfigDataProvider($awsConfig, '2012-08-10');
-        $this->db = new DynamoDbClient($dp->getConfig());
+        $this->db = $dbClient;
     }
     
     /**

--- a/src/AwsWrappers/DynamoDbTable.php
+++ b/src/AwsWrappers/DynamoDbTable.php
@@ -22,15 +22,12 @@ class DynamoDbTable
     /** @var DynamoDbClient */
     protected $dbClient;
     
-    protected $config;
-    
     protected $tableName;
     protected $attributeTypes = [];
     
-    function __construct(array $awsConfig, $tableName, $attributeTypes = [])
+    function __construct(DynamoDbClient $dbClient, $tableName, $attributeTypes = [])
     {
-        $dp                   = new AwsConfigDataProvider($awsConfig, '2012-08-10');
-        $this->dbClient       = new DynamoDbClient($dp->getConfig());
+        $this->dbClient       = $dbClient;
         $this->tableName      = $tableName;
         $this->attributeTypes = $attributeTypes;
     }
@@ -641,8 +638,8 @@ class DynamoDbTable
     {
         $cloudwatch = new CloudWatchClient(
             [
-                "profile" => $this->config['profile'],
-                "region"  => $this->config['region'],
+                "profile" => $this->dbClient->getConfig('profile'),
+                "region"  => $this->dbClient->getConfig('region'),
                 "version" => "2010-08-01",
             ]
         );


### PR DESCRIPTION
This change allows the "Out of the box" DynamoDB Client from the AWS SDK to be used, and in-turn supports whatever AWS updates via their SDK.
Personally this was the only way I found to be able to use the role-based permissions in Symfony, without having to re-declare all the permissions for this package specifically.

I've also added in serialisation of objects - eg. when one object contained another within it, or an array of objects.